### PR TITLE
Hide Header when app cookie is available

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "vendor": "vtex",
+  "vendor": "thefoschini",
   "name": "store-header",
   "version": "2.29.0",
   "title": "VTEX Store Header",

--- a/react/components/CustomHeader.tsx
+++ b/react/components/CustomHeader.tsx
@@ -1,7 +1,9 @@
-import type { FunctionComponent } from 'react'
+import { FunctionComponent, useEffect, useState } from 'react'
 import React from 'react'
-import { Block } from 'vtex.render-runtime'
+import { Block, useRuntime } from 'vtex.render-runtime'
 import { useDevice } from 'vtex.device-detector'
+
+
 
 const enum Device {
   mobile = 'mobile',
@@ -34,10 +36,30 @@ const CustomHeaderLayout = React.memo(({ device }: { device: Device }) => {
 CustomHeaderLayout.displayName = 'CustomHeaderLayout'
 
 const CustomHeader: FunctionComponent = () => {
+  const runtime = useRuntime()
+  const currentPage = runtime.page
+  const isOrderPlacedPage = currentPage === 'store.orderplaced'
+  const [isHidden, setIsHidden] = useState(isOrderPlacedPage)
   const { isMobile } = useDevice()
 
+
+  useEffect(() => {
+    if (isOrderPlacedPage) {
+      const checkCookie = () => {
+        const cookies = document.cookie.split(';')
+        const isAppCookie = cookies.some(cookie => cookie.trim().startsWith('is_app='))
+        setIsHidden(isAppCookie)
+      }
+      checkCookie()
+    } else {
+      setIsHidden(false)
+    }
+  }, [isOrderPlacedPage])
+
   return (
-    <CustomHeaderLayout device={isMobile ? Device.mobile : Device.desktop} />
+    <div style={{ display: isHidden ? 'none' : 'block' }}>
+      <CustomHeaderLayout device={isMobile ? Device.mobile : Device.desktop} />
+    </div>
   )
 }
 

--- a/react/components/CustomHeader.tsx
+++ b/react/components/CustomHeader.tsx
@@ -47,7 +47,7 @@ const CustomHeader: FunctionComponent = () => {
     if (isOrderPlacedPage) {
       const checkCookie = () => {
         const cookies = document.cookie.split(';')
-        const isAppCookie = cookies.some(cookie => cookie.trim().startsWith('is_app='))
+        const isAppCookie = cookies.some(cookie => cookie.trim().startsWith('is_app=true'))
         setIsHidden(isAppCookie)
       }
       checkCookie()


### PR DESCRIPTION
#### What problem is this solving?



Note: This change required forking the repo to achieve the necessary level of integration for a smooth app user experience.


The header HTML is always rendered to to maintain crawlability
 -On the order placed page, we check for the presence of the `is_app` cookie
- If the `is_app` cookie is found on the order placed page, the header is hidden via CSS


https://github.com/user-attachments/assets/f9f56ade-4675-4067-83bd-cdfc6992ae70


<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](Link goes here!)

https://gifttest--thefoschini.myvtex.com/checkout/orderPlaced/?og=B7286539

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
